### PR TITLE
Refactor Accessories

### DIFF
--- a/src/accessories/platformAccessory.ts
+++ b/src/accessories/platformAccessory.ts
@@ -18,8 +18,8 @@ export abstract class MiHomePlatformAccessory {
     // set accessory information
     this.accessory.getService(this.platform.Service.AccessoryInformation)!
       .setCharacteristic(this.platform.Characteristic.Manufacturer, MANUFACTURER)
-      .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.device_type)
-      .setCharacteristic(this.platform.Characteristic.Name, this.accessory.context.label)
+      .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.device.device_type)
+      .setCharacteristic(this.platform.Characteristic.Name, this.accessory.context.device.label)
       .setCharacteristic(this.platform.Characteristic.AppMatchingIdentifier, APP_MATCHING_IDENTIFIER);
   }
 

--- a/src/accessories/platformAccessory.ts
+++ b/src/accessories/platformAccessory.ts
@@ -54,9 +54,6 @@ export abstract class MiHomePlatformAccessory {
    */
   async getOn(callback: CharacteristicGetCallback) {
 
-    // The Energenie API doesn't actually return an accurate value for power_state.
-    // If the switch is toggled phsyically or via another route, i.e. Alexa, the new
-    // value is not reported by the API. Investigations ongoing to find a solution.
     try {
       const device = await this.platform.EnergenieApi.getSubdeviceInfo(this.accessory.context.device.id);
       const isOn = device.power_state === 1;

--- a/src/accessories/platformAccessory.ts
+++ b/src/accessories/platformAccessory.ts
@@ -1,5 +1,6 @@
-import type { PlatformAccessory } from 'homebridge';
+import type { PlatformAccessory, CharacteristicValue, CharacteristicSetCallback, CharacteristicGetCallback } from 'homebridge';
 
+import { MANUFACTURER, APP_MATCHING_IDENTIFIER } from '../settings';
 import { MiHomeGatewayPlatform } from '../platform';
 
 /**
@@ -13,7 +14,60 @@ export abstract class MiHomePlatformAccessory {
     protected readonly platform: MiHomeGatewayPlatform,
     protected readonly accessory: PlatformAccessory,
   ) {
-    // TODO
+
+    // set accessory information
+    this.accessory.getService(this.platform.Service.AccessoryInformation)!
+      .setCharacteristic(this.platform.Characteristic.Manufacturer, MANUFACTURER)
+      .setCharacteristic(this.platform.Characteristic.Model, this.accessory.context.device_type)
+      .setCharacteristic(this.platform.Characteristic.Name, this.accessory.context.label)
+      .setCharacteristic(this.platform.Characteristic.AppMatchingIdentifier, APP_MATCHING_IDENTIFIER);
+  }
+
+  /**
+   * Handle "SET" requests from HomeKit
+   * These are sent when the user changes the state of an accessory, for example, turning on a Switch.
+   */
+  async setOn(value: CharacteristicValue, callback: CharacteristicSetCallback) {
+    
+    const action = value ? 'power_on' : 'power_off';
+
+    try {
+      await this.platform.EnergenieApi.toggleSocketPower(this.accessory.context.device.id, action);
+
+      this.platform.log.debug('Set Characteristic On ->', value);
+
+      callback(null);
+    } catch (err) {
+      this.platform.log.error('Error setting Characteristic On ->', action, err);
+      callback(err);
+    }
+  }
+
+  /**
+   * Handle the "GET" requests from HomeKit
+   * These are sent when HomeKit wants to know the current state of the accessory.
+   * 
+   * The Energenie API doesn't actually return an accurate value for power_state.
+   * If the switch is toggled phsyically or via another route, for example; Alexa,
+   * the new value is not reported by the API.
+   * Investigations ongoing to find a solution.
+   */
+  async getOn(callback: CharacteristicGetCallback) {
+
+    // The Energenie API doesn't actually return an accurate value for power_state.
+    // If the switch is toggled phsyically or via another route, i.e. Alexa, the new
+    // value is not reported by the API. Investigations ongoing to find a solution.
+    try {
+      const device = await this.platform.EnergenieApi.getSubdeviceInfo(this.accessory.context.device.id);
+      const isOn = device.power_state === 1;
+
+      this.platform.log.debug('Get Characteristic On ->', isOn);
+
+      callback(null, isOn);
+    } catch (err) {
+      this.platform.log.error('Error getting Characteristic On ->', err);
+      callback(err);
+    }
   }
 
 }

--- a/src/accessories/switchAccessory.ts
+++ b/src/accessories/switchAccessory.ts
@@ -35,13 +35,7 @@ export class SwitchAccessory extends MiHomePlatformAccessory {
     //
     // Here we update the state.
     setInterval(() => {
-      // assign the current brightness a random value between 0 and 100
-      const currentBrightness = Math.floor(Math.random() * 100);
-
-      // push the new value to HomeKit
-      this.service.updateCharacteristic(this.platform.Characteristic.Brightness, currentBrightness);
-
-      this.platform.log.debug('Pushed updated current Brightness state to HomeKit:', currentBrightness);
+      this.updateOn();
     }, UPDATE_STATE_INTERVAL);
   }
 

--- a/src/accessories/switchAccessory.ts
+++ b/src/accessories/switchAccessory.ts
@@ -1,21 +1,11 @@
 import { MiHomeGatewayPlatform } from '../platform';
-import {
-  PlatformAccessory,
-  CharacteristicEventTypes,
-  CharacteristicValue,
-  CharacteristicSetCallback,
-  CharacteristicGetCallback,
-  Service,
-} from 'homebridge';
+import { Service, PlatformAccessory, CharacteristicEventTypes } from 'homebridge';
+
+import { UPDATE_STATE_INTERVAL } from '../settings';
 import { MiHomePlatformAccessory } from './platformAccessory';
 
 export class SwitchAccessory extends MiHomePlatformAccessory {
-
-  private states = {
-    On: false,
-  };
-
-  private service: Service;
+  protected service: Service;
 
   constructor(
     platform: MiHomeGatewayPlatform,
@@ -23,11 +13,6 @@ export class SwitchAccessory extends MiHomePlatformAccessory {
   ) {
 
     super(platform, accessory);
-
-    // set accessory information
-    this.accessory.getService(this.platform.Service.AccessoryInformation)!
-      .setCharacteristic(this.platform.Characteristic.Manufacturer, 'Energenie')
-      .setCharacteristic(this.platform.Characteristic.Model, accessory.context);
 
     // get the Switch service if it exists, otherwise create a new Switch service
     // you can create multiple services for each accessory
@@ -38,62 +23,50 @@ export class SwitchAccessory extends MiHomePlatformAccessory {
     this.service.setCharacteristic(this.platform.Characteristic.Name, accessory.context.device.label);
 
     // each service must implement at-minimum the "required characteristics" for the given service type
-    // see https://github.com/homebridge/HAP-NodeJS/blob/master/src/lib/gen/HomeKit.ts
+    // see https://developers.homebridge.io/#/service/Switch
 
     // register handlers for the On/Off Characteristic
     this.service.getCharacteristic(this.platform.Characteristic.On)
-      .on(CharacteristicEventTypes.SET, this.setOn.bind(this))                // SET - bind to the `setOn` method below
-      .on(CharacteristicEventTypes.GET, this.getOn.bind(this));               // GET - bind to the `getOn` method below
+      .on(CharacteristicEventTypes.SET, this.setOn.bind(this))  // SET - bind to the `setOn` method below
+      .on(CharacteristicEventTypes.GET, this.getOn.bind(this)); // GET - bind to the `getOn` method below
+
+    // Update the state of a Characteristic asynchronously instead
+    // of using the `on('get')` handlers.
+    //
+    // Here we update the state.
+    setInterval(() => {
+      // assign the current brightness a random value between 0 and 100
+      const currentBrightness = Math.floor(Math.random() * 100);
+
+      // push the new value to HomeKit
+      this.service.updateCharacteristic(this.platform.Characteristic.Brightness, currentBrightness);
+
+      this.platform.log.debug('Pushed updated current Brightness state to HomeKit:', currentBrightness);
+    }, UPDATE_STATE_INTERVAL);
   }
 
   /**
-   * Handle "SET" requests from HomeKit
-   * These are sent when the user changes the state of an accessory, for example, turning on a Light bulb.
+   * Update the state of a Characteristic asynchronously instead
+   * of using the `on('get')` handlers.
+   * 
+   * Here we update the on / off state using
+   * the `updateCharacteristic` method.
    */
-  setOn(value: CharacteristicValue, callback: CharacteristicSetCallback) {
-    this.states.On = value as boolean;
-
-    this.platform.log.debug('Set Characteristic On ->', value);
-
-    const switchState = this.service.getCharacteristic(this.platform.Characteristic.On);
-
-    if (switchState.value !== value) {
-      const endpoint = this.states.On ? 'power_on' : 'power_off';
-      this.platform.log.debug('start %s', endpoint);
-
-      this.platform.EnergenieApi.toggleSocketPower(this.accessory.context.device.id, endpoint)
-        .then(() => {
-          this.platform.log.debug('%s complete', endpoint);
-          callback(null);
-        })
-        .catch(err => {
-          this.platform.log.debug('Error \'%s\' setting switch state', err);
-          callback(err || new Error('Error setting switch state.'));
-        });
-    } else {
-      callback(null);
-    }
-  }
-
-  /**
-   * Handle the "GET" requests from HomeKit
-   * These are sent when HomeKit wants to know the current state of the accessory.
-  */
-  getOn(callback: CharacteristicGetCallback) {
+  async updateOn() {
 
     // The Energenie API doesn't actually return an accurate value for power_state.
     // If the switch is toggled phsyically or via another route, i.e. Alexa, the new
     // value is not reported by the API. Investigations ongoing to find a solution.
-    this.platform.EnergenieApi.getSubdeviceInfo(this.accessory.context.device.id)
-      .then(deviceInfo => {
-        this.states.On = deviceInfo.power_state === 1;
+    try {
+      const device = await this.platform.EnergenieApi.getSubdeviceInfo(this.accessory.context.device.id);
+      const isOn = device.power_state === 1;
 
-        this.platform.log.debug('Get Characteristic On ->', this.states.On);
+      // push the new value to HomeKit
+      this.service.updateCharacteristic(this.platform.Characteristic.On, isOn);
 
-        callback(null, this.states.On);
-      })
-      .catch(err => {
-        callback(err);
-      });
+      this.platform.log.debug('Pushed updated current On state to HomeKit:', isOn);
+    } catch (err) {
+      this.platform.log.error('Error pushing updated current On state to HomeKit:', err);
+    }
   }
 }

--- a/src/accessories/switchAccessory.ts
+++ b/src/accessories/switchAccessory.ts
@@ -52,13 +52,14 @@ export class SwitchAccessory extends MiHomePlatformAccessory {
     // If the switch is toggled phsyically or via another route, i.e. Alexa, the new
     // value is not reported by the API. Investigations ongoing to find a solution.
     try {
-      const device = await this.platform.EnergenieApi.getSubdeviceInfo(this.accessory.context.device.id);
-      const isOn = device.power_state === 1;
+      const device = await this.getDevice();
 
-      // push the new value to HomeKit
-      this.service.updateCharacteristic(this.platform.Characteristic.On, isOn);
+      if (device) {
+        const isOn = device.power_state === 1;
 
-      this.platform.log.debug('Pushed updated current On state to HomeKit:', isOn);
+        // push the new value to HomeKit
+        this.service.updateCharacteristic(this.platform.Characteristic.On, isOn);
+      }
     } catch (err) {
       this.platform.log.error('Error pushing updated current On state to HomeKit:', err);
     }

--- a/src/settings.ts
+++ b/src/settings.ts
@@ -12,3 +12,18 @@ export const PLUGIN_NAME = 'homebridge-mihomegateway';
  * This is the base URL of the MiHome API.
  */
 export const MIHOME_API_BASE_URL = 'https://mihome4u.co.uk/api/v1';
+
+/**
+ * This is the name of the manufacturer.
+ */
+export const MANUFACTURER = 'MiHome';
+
+/**
+ * This is the app identifier for matching.
+ */
+export const APP_MATCHING_IDENTIFIER = 'com.energenie.mihome';
+
+/**
+ * This is the interval for updating the state.
+ */
+export const UPDATE_STATE_INTERVAL = 10000;


### PR DESCRIPTION
* Add `MANUFACTURER`, `APP_MATCHING_IDENTIFIER` and `UPDATE_STATE_INTERVAL`.
* Set accessory information to `MiHomePlatformAccessory`.
* Handle `SET` and `GET` requests from HomeKit to `MiHomePlatformAccessory`.
* Update the state of a Characteristic asynchronously instead of using the `on('get')` handlers.