### PR TITLE
Fix URL Concat Issues

### DIFF
--- a/src/accessories/platformAccessory.ts
+++ b/src/accessories/platformAccessory.ts
@@ -52,16 +52,14 @@ export abstract class MiHomePlatformAccessory {
    */
   async setOn(value: CharacteristicValue, callback: CharacteristicSetCallback) {
     
-    const action = value ? 'power_on' : 'power_off';
-
     try {
-      await this.platform.EnergenieApi.toggleSocketPower(this.accessory.context.device.id, action);
+      await this.platform.EnergenieApi.toggleSocketPower(this.accessory.context.device.id, value === true);
 
       this.platform.log.debug('Set Characteristic On ->', value);
 
       callback(null);
     } catch (err) {
-      this.platform.log.error('Error setting Characteristic On ->', action, err);
+      this.platform.log.error('Error setting Characteristic On ->', value, err);
       callback(err);
     }
   }

--- a/src/accessories/platformAccessory.ts
+++ b/src/accessories/platformAccessory.ts
@@ -104,7 +104,7 @@ export abstract class MiHomePlatformAccessory {
       this.accessory.context.device = device;
       return device;
     } catch (err) {
-      this.platform.log.error('Error getting subdevice information', this.accessory.context.device.label, err);
+      this.platform.log.error('Error getting subdevice information:', this.accessory.context.device.label, err);
     }
   }
 

--- a/src/energenieApi/energenieApi.ts
+++ b/src/energenieApi/energenieApi.ts
@@ -6,6 +6,7 @@ import { Logger } from 'homebridge';
 import { EnergenieAuthenticationHandler } from './energenieAuthenticationHandler';
 import { BasicCredentialHandler } from 'typed-rest-client/Handlers';
 import { IHttpClientResponse } from 'typed-rest-client/Interfaces';
+import { getUrl } from 'typed-rest-client/Util';
 import { UnauthorisedError } from './errors';
 
 export class EnergenieApi {
@@ -53,14 +54,14 @@ export class EnergenieApi {
   public toggleSocketPower(id: number, action: string): Promise<void> {
     const params = `params={ "id": ${id} }`;
 
-    return this.makeHttpRequest(() => this.httpClient.post(`${this.baseUrl}subdevices/` + action, params),
+    return this.makeHttpRequest(() => this.httpClient.post(`${getUrl('subdevices', this.baseUrl)}` + action, params),
       `toggleSocketPower/${action}`);
   }
 
   public getSubdeviceInfo(id: number): Promise<SubDevice> {
     const params = `params={ "id": ${id} }`;
 
-    return this.makeHttpRequest(() => this.httpClient.post(`${this.baseUrl}subdevices/show`, params),
+    return this.makeHttpRequest(() => this.httpClient.post(`${getUrl('subdevices/show', this.baseUrl)}`, params),
       'getSubDeviceInfo');
   }
 

--- a/src/energenieApi/energenieApi.ts
+++ b/src/energenieApi/energenieApi.ts
@@ -54,7 +54,7 @@ export class EnergenieApi {
   public toggleSocketPower(id: number, value: boolean): Promise<void> {
     const params = `params={ "id": ${id} }`;
     const action = value ? 'power_on' : 'power_off';
-    const url = getUrl('subdevices' + action, this.baseUrl);
+    const url = getUrl('subdevices/' + action, this.baseUrl);
 
     return this.makeHttpRequest(() => this.httpClient.post(url, params),
       `toggleSocketPower/${action}`);

--- a/src/energenieApi/energenieApi.ts
+++ b/src/energenieApi/energenieApi.ts
@@ -51,8 +51,9 @@ export class EnergenieApi {
       'getSubDevices');
   }
 
-  public toggleSocketPower(id: number, action: string): Promise<void> {
+  public toggleSocketPower(id: number, value: boolean): Promise<void> {
     const params = `params={ "id": ${id} }`;
+    const action = value ? 'power_on' : 'power_off';
     const url = getUrl('subdevices' + action, this.baseUrl);
 
     return this.makeHttpRequest(() => this.httpClient.post(url, params),

--- a/src/energenieApi/energenieApi.ts
+++ b/src/energenieApi/energenieApi.ts
@@ -53,15 +53,17 @@ export class EnergenieApi {
 
   public toggleSocketPower(id: number, action: string): Promise<void> {
     const params = `params={ "id": ${id} }`;
+    const url = getUrl('subdevices' + action, this.baseUrl);
 
-    return this.makeHttpRequest(() => this.httpClient.post(`${getUrl('subdevices', this.baseUrl)}` + action, params),
+    return this.makeHttpRequest(() => this.httpClient.post(url, params),
       `toggleSocketPower/${action}`);
   }
 
   public getSubdeviceInfo(id: number): Promise<SubDevice> {
     const params = `params={ "id": ${id} }`;
+    const url = getUrl('subdevices/show', this.baseUrl);
 
-    return this.makeHttpRequest(() => this.httpClient.post(`${getUrl('subdevices/show', this.baseUrl)}`, params),
+    return this.makeHttpRequest(() => this.httpClient.post(url, params),
       'getSubDeviceInfo');
   }
 


### PR DESCRIPTION
Use `getUrl` to build the URL correctly (fixes issue with base URL possibly containing or not containing a slash at the end of config)